### PR TITLE
Don't make settings active

### DIFF
--- a/samples/cloudfuse_plugin/src/nx/vms_server_plugins/analytics/stub/settings/settings_model.h
+++ b/samples/cloudfuse_plugin/src/nx/vms_server_plugins/analytics/stub/settings/settings_model.h
@@ -85,8 +85,7 @@ static const std::string kEngineSettingsModel = /*suppress newline*/ 1 + R"json(
                     "description": "Cloud bucket access key ID",
                     "defaultValue": "",
                     "validationErrorMessage": "Access key ID must be >=16 alphanumeric characters (uppercase or 2-7).",
-                    "validationRegex": "^[A-Z2-7]{16,128}$",
-                    "isActive": true
+                    "validationRegex": "^[A-Z2-7]{16,128}$"
                 },
                 {
                     "type": "PasswordField",
@@ -96,8 +95,7 @@ static const std::string kEngineSettingsModel = /*suppress newline*/ 1 + R"json(
                     "description": "Cloud bucket secret key",
                     "defaultValue": "",
                     "validationErrorMessage": "Secret key must be 32 or 40 alphanumeric-plus-slash characters",
-                    "validationRegex": "^[A-Za-z0-9/+=]{32,40}$",
-                    "isActive": true
+                    "validationRegex": "^[A-Za-z0-9/+=]{32,40}$"
                 }
             ]
         },


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

It appears in testing that leaving these as active settings causes the server to crash on Windows. If they are not set to active it works fine.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #