### PR TITLE
Unmount cloudfuse on shutdown

### DIFF
--- a/samples/cloudfuse_plugin/src/nx/vms_server_plugins/analytics/stub/settings/engine.cpp
+++ b/samples/cloudfuse_plugin/src/nx/vms_server_plugins/analytics/stub/settings/engine.cpp
@@ -69,6 +69,13 @@ Engine::Engine(Plugin *plugin)
 
 Engine::~Engine()
 {
+    NX_PRINT << "cloudfuse Engine::~Engine unmount cloudfuse" << std::endl;
+    const processReturn unmountRet = cfManager.unmount();
+    if (unmountRet.errCode != 0)
+    {
+        NX_PRINT << "cloudfuse Engine::~Engine failed to unmount cloudfuse with error: " + unmountRet.output
+                 << std::endl;
+    }
 }
 
 void Engine::doObtainDeviceAgent(Result<IDeviceAgent *> *outResult, const IDeviceInfo *deviceInfo)


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Cloudfuse now unmounts when the Network Optix server is shutdown.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #