### PR TITLE
Retry settings if settings are the same but cloudfuse is not mounted

### DIFF
--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -148,6 +148,12 @@ bool Engine::processActiveSettings(Json::object *model, std::map<std::string, st
 
 bool Engine::settingsChanged()
 {
+    // If cloudfuse is not mounted and settings are the same, then return true so
+    // it tries to mount again.
+    if (!cfManager.isMounted()) {
+        return true;
+    }
+
     std::map<std::string, std::string> prevValues = prevSettings();
     std::map<std::string, std::string> newValues = currentSettings();
     if (newValues == prevValues)

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -150,7 +150,8 @@ bool Engine::settingsChanged()
 {
     // If cloudfuse is not mounted and settings are the same, then return true so
     // it tries to mount again.
-    if (!cfManager.isMounted()) {
+    if (!cfManager.isMounted())
+    {
         return true;
     }
 


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

If cloudfuse settings have not changed, but cloudfuse is not yet mounted, then it should retry the settings to allow the mount to try and succeed again.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #