### PR TITLE
Enable stderr logging

### DIFF
--- a/src/plugin/settings/device_agent.cpp
+++ b/src/plugin/settings/device_agent.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 
-#define NX_PRINT_PREFIX (this->logUtils.printPrefix)
 #include <nx/kit/debug.h>
 #include <nx/kit/utils.h>
 #include <nx/sdk/helpers/active_setting_changed_response.h>

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -12,6 +12,7 @@
 #include <openssl/rand.h>
 #include <string.h>
 #include <thread>
+#include <fstream>
 
 #include "actions.h"
 #include "active_settings_rules.h"
@@ -22,6 +23,7 @@
 #include "cloudfuse_helper.h"
 
 #include <nx/kit/debug.h>
+#include <nx/kit/ini_config.h>
 #include <nx/sdk/helpers/active_setting_changed_response.h>
 #include <nx/sdk/helpers/error.h>
 #include <utils.h>
@@ -39,10 +41,15 @@ using namespace nx::sdk;
 using namespace nx::sdk::analytics;
 using namespace nx::kit;
 
+void enableLogging(std::string iniDir);
+
 Engine::Engine(Plugin *plugin)
     : nx::sdk::analytics::Engine(NX_DEBUG_ENABLE_OUTPUT, plugin->instanceId()), m_plugin(plugin), cfManager()
 {
+    // logging will begin the _next_ time the mediaserver starts
+    enableLogging(IniConfig::iniFilesDir());
     NX_PRINT << "cloudfuse Engine::Engine";
+
     for (const auto &entry : kActiveSettingsRules)
     {
         const ActiveSettingsBuilder::ActiveSettingKey key = entry.first;
@@ -102,6 +109,26 @@ std::string Engine::manifestString() const
 )json";
 
     return result;
+}
+
+void enableLogging(std::string iniDir)
+{
+    // enable logging by touching stdout and stderr redirect files
+    if (!fs::is_directory(iniDir))
+    {
+        fs::create_directories(iniDir);
+    }
+    const std::string processName = utils::getProcessName();
+    const std::string stdoutFilename = iniDir + processName + "_stdout.log";
+    const std::string stderrFilename = iniDir + processName + "_stderr.log";
+    if (!fs::exists(stdoutFilename) || !fs::exists(stderrFilename))
+    {
+        NX_PRINT << "cloudfuse Engine::enableLogging - creating files";
+        std::ofstream stdoutFile(stdoutFilename);
+        std::ofstream stderrFile(stderrFilename);
+        // the service will need to be restarted for logging to actually begin
+    }
+    NX_PRINT << "cloudfuse Engine::enableLogging - plugin stderr logging file: " + stderrFilename;
 }
 
 bool Engine::processActiveSettings(Json::object *model, std::map<std::string, std::string> *values,

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -6,13 +6,13 @@
 #include <algorithm>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <string.h>
 #include <thread>
-#include <fstream>
 
 #include "actions.h"
 #include "active_settings_rules.h"

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -21,7 +21,6 @@
 
 #include "cloudfuse_helper.h"
 
-#define NX_PRINT_PREFIX (this->logUtils.printPrefix)
 #include <nx/kit/debug.h>
 #include <nx/sdk/helpers/active_setting_changed_response.h>
 #include <nx/sdk/helpers/error.h>


### PR DESCRIPTION
The mediaserver will log our NX_PRINT output to stderr. On Linux, that is written to a service log (visible with journalctl), but on Windows it is lost.
To capture this output to a file, developers are told to use "OutputRedirector" by creating output redirection files, as described in the Nx Meta documentation, and on the forum: [here](https://support.networkoptix.com/hc/en-us/community/posts/360051982553/comments/360013336354).
With this change, the plugin will go and create those files itself, so that NX_PRINT output will be captured in deployment.
NOTE: output redirection requires restarting the mediaserver again _after the plugin creates the redirection files_.
This logging method is not great, but it's an improvement over our current situation (no plugin logs are captured on Windows).

### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests