### PR TITLE
Flag Advanced Settings

### DIFF
--- a/src/plugin/settings/device_agent.cpp
+++ b/src/plugin/settings/device_agent.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 
+#define NX_PRINT_PREFIX (this->logUtils.printPrefix)
 #include <nx/kit/debug.h>
 #include <nx/kit/utils.h>
 #include <nx/sdk/helpers/active_setting_changed_response.h>

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -22,6 +22,7 @@
 
 #include "cloudfuse_helper.h"
 
+// #define NX_PRINT_PREFIX (this->logUtils.printPrefix)
 #include <nx/kit/debug.h>
 #include <nx/kit/ini_config.h>
 #include <nx/sdk/helpers/active_setting_changed_response.h>

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -488,9 +488,7 @@ nx::sdk::Error Engine::spawnMount()
 #endif
     if (mountRet.errCode != 0)
     {
-        std::string errorMessage = "Unable to launch mount with error: " + mountRet.output;
-        NX_PRINT << errorMessage;
-        return error(ErrorCode::internalError, errorMessage);
+        return error(ErrorCode::internalError, "Unable to launch mount with error: " + mountRet.output);
     }
 
     // Mount might not show up immediately, so wait for mount to appear
@@ -505,9 +503,7 @@ nx::sdk::Error Engine::spawnMount()
 
     if (!m_cfManager.isMounted())
     {
-        std::string errorMessage = "Cloudfuse was not able to successfully mount";
-        NX_PRINT << errorMessage;
-        return error(ErrorCode::internalError, errorMessage);
+        return error(ErrorCode::internalError, "Cloudfuse was not able to successfully mount");
     }
 
     return Error(ErrorCode::noError, nullptr);

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -139,7 +139,7 @@ void enableLogging(std::string iniDir)
 bool Engine::updateModel(Json::object *model, bool mountSuccessful) const
 {
     NX_PRINT << "cloudfuse Engine::updateModel";
-    
+
     // prepare the new status item
     auto statusJson = mountSuccessful ? kStatusSuccess : kStatusFailure;
     std::string error;
@@ -149,13 +149,13 @@ bool Engine::updateModel(Json::object *model, bool mountSuccessful) const
         NX_PRINT << "Failed to parse status JSON with error: " << error;
         return false;
     }
-    
+
     // find where to put it
     auto items = (*model)[kItems];
     auto itemsArray = items.array_items();
     // find the status banner, if it's already present
     auto statusBannerIt = std::find_if(itemsArray.begin(), itemsArray.end(),
-        [](Json &item) { return item[kName].string_value() == kStatusBannerId; });
+                                       [](Json &item) { return item[kName].string_value() == kStatusBannerId; });
     // if the banner is not there, add it
     if (statusBannerIt == itemsArray.end())
     {

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -22,6 +22,7 @@
 
 #include "cloudfuse_helper.h"
 
+// TOOD: get NX_PRINT_PREFIX working with non-member helper functions
 // #define NX_PRINT_PREFIX (this->logUtils.printPrefix)
 #include <nx/kit/debug.h>
 #include <nx/kit/ini_config.h>

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -22,7 +22,7 @@
 
 #include "cloudfuse_helper.h"
 
-// TOOD: get NX_PRINT_PREFIX working with non-member helper functions
+// TODO: get NX_PRINT_PREFIX working with non-member helper functions
 // #define NX_PRINT_PREFIX (this->logUtils.printPrefix)
 #include <nx/kit/debug.h>
 #include <nx/kit/ini_config.h>

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -200,23 +200,26 @@ bool Engine::settingsChanged()
     {
         return true;
     }
-    // endpoint
-    if (m_prevSettings[kEndpointUrlTextFieldId] != newValues[kEndpointUrlTextFieldId])
+    if (!credentialsOnly)
     {
-        // if they're different, but both amount to the same thing, then there is no effective change
-        bool prevIsDefault = m_prevSettings[kEndpointUrlTextFieldId] == kDefaultEndpoint ||
-                             m_prevSettings[kEndpointUrlTextFieldId] == "";
-        bool newIsDefault =
-            newValues[kEndpointUrlTextFieldId] == kDefaultEndpoint || newValues[kEndpointUrlTextFieldId] == "";
-        if (!prevIsDefault || !newIsDefault)
+        // endpoint
+        if (m_prevSettings[kEndpointUrlTextFieldId] != newValues[kEndpointUrlTextFieldId])
+        {
+            // if they're different, but both amount to the same thing, then there is no effective change
+            bool prevIsDefault = m_prevSettings[kEndpointUrlTextFieldId] == kDefaultEndpoint ||
+                                 m_prevSettings[kEndpointUrlTextFieldId] == "";
+            bool newIsDefault =
+                newValues[kEndpointUrlTextFieldId] == kDefaultEndpoint || newValues[kEndpointUrlTextFieldId] == "";
+            if (!prevIsDefault || !newIsDefault)
+            {
+                return true;
+            }
+        }
+        // bucket name
+        if (m_prevSettings[kBucketNameTextFieldId] != newValues[kBucketNameTextFieldId])
         {
             return true;
         }
-    }
-    // bucket name
-    if (m_prevSettings[kBucketNameTextFieldId] != newValues[kBucketNameTextFieldId])
-    {
-        return true;
     }
     // nothing we care about changed
     return false;
@@ -343,10 +346,15 @@ nx::sdk::Error Engine::validateMount()
     std::map<std::string, std::string> values = currentSettings();
     std::string keyId = values[kKeyIdTextFieldId];
     std::string secretKey = values[kSecretKeyPasswordFieldId];
-    std::string endpointUrl = values[kEndpointUrlTextFieldId];
     std::string endpointRegion = "us-east-1";
-    std::string bucketName = values[kBucketNameTextFieldId]; // The default empty string will cause cloudfuse
-                                                             // to select first available bucket
+    std::string endpointUrl = kDefaultEndpoint;
+    std::string bucketName = "";
+    if (!credentialsOnly)
+    {
+        endpointUrl = values[kEndpointUrlTextFieldId];
+        bucketName = values[kBucketNameTextFieldId]; // The default empty string will cause cloudfuse
+                                                     // to select first available bucket
+    }
     std::string mountDir = m_cfManager.getMountDir();
     std::string fileCacheDir = m_cfManager.getFileCacheDir();
     // Unmount before mounting

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -139,7 +139,7 @@ void enableLogging(std::string iniDir)
 bool Engine::updateModel(Json::object *model, bool mountSuccessful) const
 {
     NX_PRINT << "cloudfuse Engine::updateModel";
-
+    
     // prepare the new status item
     auto statusJson = mountSuccessful ? kStatusSuccess : kStatusFailure;
     std::string error;
@@ -149,13 +149,13 @@ bool Engine::updateModel(Json::object *model, bool mountSuccessful) const
         NX_PRINT << "Failed to parse status JSON with error: " << error;
         return false;
     }
-
+    
     // find where to put it
     auto items = (*model)[kItems];
     auto itemsArray = items.array_items();
     // find the status banner, if it's already present
     auto statusBannerIt = std::find_if(itemsArray.begin(), itemsArray.end(),
-                                       [](Json &item) { return item[kName].string_value() == kStatusBannerId; });
+        [](Json &item) { return item[kName].string_value() == kStatusBannerId; });
     // if the banner is not there, add it
     if (statusBannerIt == itemsArray.end())
     {
@@ -524,6 +524,15 @@ void Engine::doGetSettingsOnActiveSettingChange(Result<const IActiveSettingChang
     const std::string settingId(activeSettingChangedAction->activeSettingName());
 
     std::map<std::string, std::string> values = toStdMap(shareToPtr(activeSettingChangedAction->settingsValues()));
+
+    // if (!updateModel(&model, &values, {settingId}))
+    // {
+    //     std::string errorMessage = "Unable to process the active settings section";
+    //     NX_PRINT << errorMessage;
+    //     *outResult = error(ErrorCode::internalError, errorMessage);
+
+    //     return;
+    // }
 
     const auto settingsResponse = makePtr<SettingsResponse>();
     settingsResponse->setValues(makePtr<StringMap>(values));

--- a/src/plugin/settings/settings_model.h
+++ b/src/plugin/settings/settings_model.h
@@ -56,7 +56,8 @@ static const std::string kStatusBannerId = "connectionStatus";
 static const std::string kStatusSuccess = R"json(
         {
             "type": "Banner",
-            "name": ")json" + kStatusBannerId + R"json(",
+            "name": ")json" + kStatusBannerId +
+                                          R"json(",
             "icon": "info",
             "text": "Cloud storage connected successfully!"
         }
@@ -65,7 +66,8 @@ static const std::string kStatusSuccess = R"json(
 static const std::string kStatusFailure = R"json(
         {
             "type": "Banner",
-            "name": ")json" + kStatusBannerId + R"json(",
+            "name": ")json" + kStatusBannerId +
+                                          R"json(",
             "icon": "warning",
             "text": "Cloud storage connection failed!"
         }

--- a/src/plugin/settings/settings_model.h
+++ b/src/plugin/settings/settings_model.h
@@ -56,8 +56,7 @@ static const std::string kStatusBannerId = "connectionStatus";
 static const std::string kStatusSuccess = R"json(
         {
             "type": "Banner",
-            "name": ")json" + kStatusBannerId +
-                                          R"json(",
+            "name": ")json" + kStatusBannerId + R"json(",
             "icon": "info",
             "text": "Cloud storage connected successfully!"
         }
@@ -66,8 +65,7 @@ static const std::string kStatusSuccess = R"json(
 static const std::string kStatusFailure = R"json(
         {
             "type": "Banner",
-            "name": ")json" + kStatusBannerId +
-                                          R"json(",
+            "name": ")json" + kStatusBannerId + R"json(",
             "icon": "warning",
             "text": "Cloud storage connection failed!"
         }

--- a/src/plugin/settings/settings_model.h
+++ b/src/plugin/settings/settings_model.h
@@ -51,6 +51,101 @@ static const std::string kGermanCitiesSettingsModelPart = /*suppress newline*/ 1
 static const std::string kRegularSettingsModelPart2 = /*suppress newline*/ 1 + R"json(")json";
 // ------------------------------------------------------------------------------------------------
 
+// Enable this flag hide all but the credentials section
+// NOTE: enabling this will prevent the user from changing the default endpoint (kDefaultEndpoint)
+// Only set this flag true if you want to tie your users to a specific cloud storage endpoint
+static const bool credentialsOnly = false;
+
+// credentials
+static const std::string kKeyIdTextFieldId = "keyId";
+static const std::string kSecretKeyPasswordFieldId = "secretKey";
+static const std::string kCheckCredentialsButtonId = "checkCredentialsButton";
+static const std::string kCredentialGroupBox = R"json(
+        {
+            "type": "GroupBox",
+            "caption": "Credentials",
+            "items":
+            [
+                {
+                    "type": "TextField",
+                    "name": ")json" + kKeyIdTextFieldId +
+                                               R"json(",
+                    "caption": "Access Key ID",
+                    "description": "Cloud bucket access key ID",
+                    "defaultValue": "",
+                    "validationErrorMessage": "Access key ID must be >=16 alphanumeric characters (uppercase or 2-7).",
+                    "validationRegex": "^[A-Z1-9]{16,128}$"
+                },
+                {
+                    "type": "PasswordField",
+                    "name": ")json" + kSecretKeyPasswordFieldId +
+                                               R"json(",
+                    "caption": "Secret Key",
+                    "description": "Cloud bucket secret key",
+                    "defaultValue": "",
+                    "validationErrorMessage": "Secret key must be 32 or 40 alphanumeric-plus-slash characters",
+                    "validationRegex": "^[A-Za-z0-9\/+=]{32,128}$"
+                }
+            ]
+        })json";
+
+// advanced
+static const std::string kEndpointUrlTextFieldId = "endpointUrl";
+static const std::string kDefaultEndpoint = "https://s3.us-east-1.lyvecloud.seagate.com";
+static const std::string kBucketNameTextFieldId = "bucketName";
+static const std::string kAdvancedGroupBox = R"json(
+        {
+            "type": "GroupBox",
+            "caption": ")json" + kAdvancedSettingsGroupBoxCaption +
+                                             R"json(",
+            "items":
+            [
+                {
+                    "type": "TextField",
+                    "name": ")json" + kEndpointUrlTextFieldId +
+                                             R"json(",
+                    "caption": "Endpoint URL",
+                    "description": "Set a different endpoint (different region or service)",
+                    "defaultValue": ")json" + kDefaultEndpoint +
+                                             R"json(",
+                    "validationErrorMessage": "Endpoint must be a URL (begin with 'http[s]://').",
+                    "validationRegex": "(^$)|(^https?:\/\/.+$)",
+                    "validationRegexFlags": "i"
+                },
+                {
+                    "type": "TextField",
+                    "name": ")json" + kBucketNameTextFieldId +
+                                             R"json(",
+                    "caption": "Bucket Name",
+                    "description": "Specify a bucket name (leave empty to let the system automatically detect your bucket)",
+                    "defaultValue": "",
+                    "validationErrorMessage": "Bucket name can only contain lowercase letters, numbers, dashes, and dots.",
+                    "validationRegex": "^[-.a-z0-9]*$"
+                }
+            ]
+        })json";
+
+static const std::string kPluginWebsiteLink = R"json(
+        {
+            "type": "Link",
+            "caption": "Plugin Website",
+            "url": "https://github.com/Seagate/nx-lyve-cloud-plugin"
+        })json";
+
+// gather settings items together
+static const std::string kSettingsItems =
+    kCredentialGroupBox + (credentialsOnly ? "" : ("," + kAdvancedGroupBox + "," + kPluginWebsiteLink));
+
+// top-level settings model
+static const std::string kEngineSettingsModel = /*suppress newline*/ 1 + R"json(
+{
+    "type": "Settings",
+    "items":
+    [)json" + kSettingsItems + R"json(
+    ]
+}
+)json";
+
 // status
 static const std::string kStatusBannerId = "connectionStatus";
 static const std::string kStatusSuccess = R"json(
@@ -62,7 +157,6 @@ static const std::string kStatusSuccess = R"json(
             "text": "Cloud storage connected successfully!"
         }
 )json";
-
 static const std::string kStatusFailure = R"json(
         {
             "type": "Banner",
@@ -71,86 +165,6 @@ static const std::string kStatusFailure = R"json(
             "icon": "warning",
             "text": "Cloud storage connection failed!"
         }
-)json";
-
-// credentials
-static const std::string kKeyIdTextFieldId = "keyId";
-static const std::string kSecretKeyPasswordFieldId = "secretKey";
-static const std::string kCheckCredentialsButtonId = "checkCredentialsButton";
-// advanced
-static const std::string kEndpointUrlTextFieldId = "endpointUrl";
-static const std::string kDefaultEndpoint = "https://s3.us-east-1.lyvecloud.seagate.com";
-static const std::string kBucketNameTextFieldId = "bucketName";
-// top-level settings model
-static const std::string kEngineSettingsModel = /*suppress newline*/ 1 + R"json(
-{
-    "type": "Settings",
-    "items":
-    [
-        {
-            "type": "GroupBox",
-            "caption": "Credentials",
-            "items":
-            [
-                {
-                    "type": "TextField",
-                    "name": ")json" + kKeyIdTextFieldId +
-                                                R"json(",
-                    "caption": "Access Key ID",
-                    "description": "Cloud bucket access key ID",
-                    "defaultValue": "",
-                    "validationErrorMessage": "Access key ID must be >=16 alphanumeric characters (uppercase or 2-7).",
-                    "validationRegex": "^[A-Z1-9]{16,128}$"
-                },
-                {
-                    "type": "PasswordField",
-                    "name": ")json" + kSecretKeyPasswordFieldId +
-                                                R"json(",
-                    "caption": "Secret Key",
-                    "description": "Cloud bucket secret key",
-                    "defaultValue": "",
-                    "validationErrorMessage": "Secret key must be 32 or 40 alphanumeric-plus-slash characters",
-                    "validationRegex": "^[A-Za-z0-9\/+=]{32,128}$"
-                }
-            ]
-        },
-        {
-            "type": "GroupBox",
-            "caption": ")json" + kAdvancedSettingsGroupBoxCaption +
-                                                R"json(",
-            "items":
-            [
-                {
-                    "type": "TextField",
-                    "name": ")json" + kEndpointUrlTextFieldId +
-                                                R"json(",
-                    "caption": "Endpoint URL",
-                    "description": "Set a different endpoint (different region or service)",
-                    "defaultValue": ")json" + kDefaultEndpoint +
-                                                R"json(",
-                    "validationErrorMessage": "Endpoint must be a URL (begin with 'http[s]://').",
-                    "validationRegex": "(^$)|(^https?:\/\/.+$)",
-                    "validationRegexFlags": "i"
-                },
-                {
-                    "type": "TextField",
-                    "name": ")json" + kBucketNameTextFieldId +
-                                                R"json(",
-                    "caption": "Bucket Name",
-                    "description": "Specify a bucket name (leave empty to let the system automatically detect your bucket)",
-                    "defaultValue": "",
-                    "validationErrorMessage": "Bucket name can only contain lowercase letters, numbers, dashes, and dots.",
-                    "validationRegex": "^[-.a-z0-9]*$"
-                }
-            ]
-        },
-        {
-            "type": "Link",
-            "caption": "Plugin Website",
-            "url": "https://github.com/Seagate/nx-lyve-cloud-plugin"
-        }
-    ]
-}
 )json";
 
 } // namespace settings


### PR DESCRIPTION
Add const flag which customers can set true to remove advanced settings from plugin UI.
This flag will always stay true in this repo and is for customer use only.
When the flag is true, `kDefaultEndpoint` will be used as the endpoint. This is meant to allow the customer to set a default endpoint without having to think about what Cloudfuse's default endpoint is.

### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #