### PR TITLE
Remove region

### DIFF
--- a/src/lib/cloudfuse/child_process.h
+++ b/src/lib/cloudfuse/child_process.h
@@ -38,14 +38,12 @@ class CloudfuseMngr
     processReturn dryRun(const std::string passphrase);
     processReturn mount(const std::string passphrase);
     processReturn genS3Config(const std::string accessKeyId, const std::string secretAccessKey,
-                              const std::string region, const std::string endpoint, const std::string bucketName,
-                              const std::string passphrase);
+                              const std::string endpoint, const std::string bucketName, const std::string passphrase);
 #elif defined(__linux__) || defined(__APPLE__)
     processReturn dryRun(const std::string accessKeyId, const std::string secretAccessKey,
                          const std::string passphrase);
     processReturn mount(const std::string accessKeyId, const std::string secretAccessKey, const std::string passphrase);
-    processReturn genS3Config(const std::string region, const std::string endpoint, const std::string bucketName,
-                              const std::string passphrase);
+    processReturn genS3Config(const std::string endpoint, const std::string bucketName, const std::string passphrase);
 #endif
     std::string getMountDir();
     std::string getFileCacheDir();

--- a/src/lib/cloudfuse/child_process_linux.cpp
+++ b/src/lib/cloudfuse/child_process_linux.cpp
@@ -77,7 +77,6 @@ attr_cache:
 s3storage:
   bucket-name: { BUCKET_NAME }
   endpoint: { ENDPOINT }
-  region: { AWS_REGION }
   subdirectory: )" + systemName + "\n";
 
     std::string homeEnv;
@@ -173,8 +172,8 @@ processReturn CloudfuseMngr::spawnProcess(char *const argv[], char *const envp[]
     }
 }
 
-processReturn CloudfuseMngr::genS3Config(const std::string region, const std::string endpoint,
-                                         const std::string bucketName, const std::string passphrase)
+processReturn CloudfuseMngr::genS3Config(const std::string endpoint, const std::string bucketName,
+                                         const std::string passphrase)
 {
     const std::string configArg = "--config-file=" + templateFile;
     const std::string outputArg = "--output-file=" + configFile;
@@ -190,9 +189,7 @@ processReturn CloudfuseMngr::genS3Config(const std::string region, const std::st
 
     const std::string bucketNameEnv = "BUCKET_NAME=" + bucketName;
     const std::string endpointEnv = "ENDPOINT=" + endpoint;
-    const std::string regionEnv = "AWS_REGION=" + region;
-    char *const envp[] = {const_cast<char *>(bucketNameEnv.c_str()), const_cast<char *>(endpointEnv.c_str()),
-                          const_cast<char *>(regionEnv.c_str()), NULL};
+    char *const envp[] = {const_cast<char *>(bucketNameEnv.c_str()), const_cast<char *>(endpointEnv.c_str()), NULL};
 
     return spawnProcess(argv, envp);
 }

--- a/src/lib/cloudfuse/child_process_windows.cpp
+++ b/src/lib/cloudfuse/child_process_windows.cpp
@@ -105,7 +105,6 @@ s3storage:
   secret-key: { AWS_SECRET_ACCESS_KEY }
   bucket-name: { BUCKET_NAME }
   endpoint: { ENDPOINT }
-  region: { AWS_REGION }
   subdirectory: )" + systemName + "\n";
 
     std::string appdataEnv;
@@ -262,18 +261,17 @@ processReturn CloudfuseMngr::spawnProcess(wchar_t *argv, std::wstring envp)
 }
 
 processReturn CloudfuseMngr::genS3Config(const std::string accessKeyId, const std::string secretAccessKey,
-                                         const std::string region, const std::string endpoint,
-                                         const std::string bucketName, const std::string passphrase)
+                                         const std::string endpoint, const std::string bucketName,
+                                         const std::string passphrase)
 {
     const std::string argv = "cloudfuse gen-config --config-file=" + templateFile + " --output-file=" + configFile +
                              " --temp-path=" + fileCacheDir + " --passphrase=" + passphrase;
     const std::string aws_access_key_id_env = "AWS_ACCESS_KEY_ID=" + accessKeyId;
     const std::string aws_secret_access_key_env = "AWS_SECRET_ACCESS_KEY=" + secretAccessKey;
-    const std::string aws_region_env = "AWS_REGION=" + region;
     const std::string endpoint_env = "ENDPOINT=" + endpoint;
     const std::string bucket_name_env = "BUCKET_NAME=" + bucketName;
-    const std::string envp = aws_access_key_id_env + '\0' + aws_secret_access_key_env + '\0' + aws_region_env + '\0' +
-                             endpoint_env + '\0' + bucket_name_env + '\0';
+    const std::string envp =
+        aws_access_key_id_env + '\0' + aws_secret_access_key_env + '\0' + endpoint_env + '\0' + bucket_name_env + '\0';
 
     const std::wstring wargv = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(argv);
     const std::wstring wenvp = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(envp);

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -344,7 +344,6 @@ nx::sdk::Error Engine::validateMount()
     std::string keyId = values[kKeyIdTextFieldId];
     std::string secretKey = values[kSecretKeyPasswordFieldId];
     std::string endpointUrl = values[kEndpointUrlTextFieldId];
-    std::string endpointRegion = "us-east-1";
     std::string bucketName = values[kBucketNameTextFieldId]; // The default empty string will cause cloudfuse
                                                              // to select first available bucket
     std::string mountDir = m_cfManager.getMountDir();
@@ -426,10 +425,9 @@ nx::sdk::Error Engine::validateMount()
     }
     NX_PRINT << "spawning process from genS3Config";
 #if defined(__linux__)
-    const processReturn dryGenConfig = m_cfManager.genS3Config(endpointRegion, endpointUrl, bucketName, m_passphrase);
+    const processReturn dryGenConfig = m_cfManager.genS3Config(endpointUrl, bucketName, m_passphrase);
 #elif defined(_WIN32)
-    const processReturn dryGenConfig =
-        m_cfManager.genS3Config(keyId, secretKey, endpointRegion, endpointUrl, bucketName, m_passphrase);
+    const processReturn dryGenConfig = m_cfManager.genS3Config(keyId, secretKey, endpointUrl, bucketName, m_passphrase);
 #endif
     if (dryGenConfig.errCode != 0)
     {


### PR DESCRIPTION
Cloudfuse has good code to determine the region from the endpoint alone.
This change stops the plugin dealing with the region at all.
This should fix any region issues caused by the plugin setting the region to us-east-1 when the user is using a bucket in another region.

### What type of Pull Request is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #