### PR TITLE
Use gcc-12 on Ubuntu 24.04 builds

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -26,9 +26,7 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
         build_type: [Release]
-        c_compiler: [gcc, clang]
         include:
           - os: ubuntu-24.04
             c_compiler: gcc-12

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -31,10 +31,10 @@ jobs:
         c_compiler: [gcc, clang]
         include:
           - os: ubuntu-24.04
-            c_compiler: gcc
-            cpp_compiler: g++
-            arm_c_compiler: aarch64-linux-gnu-gcc
-            arm_cpp_compiler: aarch64-linux-gnu-g++
+            c_compiler: gcc-12
+            cpp_compiler: g++-12
+            arm_c_compiler: aarch64-linux-gnu-gcc-12
+            arm_cpp_compiler: aarch64-linux-gnu-g++-12
           - os: ubuntu-24.04
             c_compiler: clang
             cpp_compiler: clang++
@@ -64,12 +64,18 @@ jobs:
   
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Install cross compiler
-      if: ${{ Contains(matrix.os, 'ubuntu') }}
+      if: ${{ Contains(matrix.os, 'ubuntu-22.04') ||  Contains(matrix.os, 'ubuntu-20.04')}}
       run: |
         sudo apt-get update
         sudo apt-get install -y g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libstdc++6-arm64-cross linux-libc-dev-arm64-cross
+
+    - name: Install gcc-12
+      if: ${{ Contains(matrix.os, 'ubuntu-24.04') }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y g++-12-aarch64-linux-gnu gcc-12-aarch64-linux-gnu gcc-12 g++-12 libstdc++6-arm64-cross linux-libc-dev-arm64-cross
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -75,7 +75,7 @@ jobs:
       if: ${{ Contains(matrix.os, 'ubuntu-24.04') }}
       run: |
         sudo apt-get update
-        sudo apt-get install -y g++-12-aarch64-linux-gnu gcc-12-aarch64-linux-gnu gcc-12 g++-12 libstdc++6-arm64-cross linux-libc-dev-arm64-cross
+        sudo apt-get install -y g++-12-aarch64-linux-gnu gcc-12-aarch64-linux-gnu gcc-12 g++-12 g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libstdc++6-arm64-cross linux-libc-dev-arm64-cross
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
         build_type: [Release]
+        c_compiler: [clang]
         include:
           - os: ubuntu-24.04
             c_compiler: gcc-12

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -26,6 +26,7 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
         build_type: [Release]
         include:
           - os: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  build:
+  build-release:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            c_compiler: gcc
-            cpp_compiler: g++
+            c_compiler: gcc-12
+            cpp_compiler: g++-12
             arm_c_compiler: aarch64-linux-gnu-gcc
             arm_cpp_compiler: aarch64-linux-gnu-g++
           - os: ubuntu-22.04
@@ -32,10 +32,16 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install cross compiler
-      if: ${{ Contains(matrix.os, 'ubuntu') }}
+      if: ${{ Contains(matrix.os, 'ubuntu-22.04') ||  Contains(matrix.os, 'ubuntu-20.04')}}
       run: |
         sudo apt-get update
         sudo apt-get install -y g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+
+    - name: Install gcc-12
+      if: ${{ Contains(matrix.os, 'ubuntu-24.04') }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y g++-12-aarch64-linux-gnu gcc-12-aarch64-linux-gnu gcc-12 g++-12
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       if: ${{ Contains(matrix.os, 'ubuntu-24.04') }}
       run: |
         sudo apt-get update
-        sudo apt-get install -y g++-12-aarch64-linux-gnu gcc-12-aarch64-linux-gnu gcc-12 g++-12
+        sudo apt-get install -y g++-12-aarch64-linux-gnu gcc-12-aarch64-linux-gnu gcc-12 g++-12 g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

Using the latest version of gcc on Ubuntu 24.04 builds will cause the plugin to fail to load in the Network Optix VMS which links to an older version of libc. Downgrading to gcc-12 on Ubuntu 24.04 fixes this issue.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #