### PR TITLE
Change bat script to fail on Windows if unable to compile

### DIFF
--- a/build_plugin.bat
+++ b/build_plugin.bat
@@ -43,11 +43,11 @@ set PLUGIN_NAME=cloudfuse_plugin
 
 set PLUGIN_BUILD_DIR=%BUILD_DIR%\%PLUGIN_NAME%
 @echo on
-    if not exist "%PLUGIN_BUILD_DIR%\" mkdir "%PLUGIN_BUILD_DIR%" || @exit /b
-    cd "%PLUGIN_BUILD_DIR%" || @exit /b
+    if not exist "%PLUGIN_BUILD_DIR%\" mkdir "%PLUGIN_BUILD_DIR%" || @exit /b 70
+    cd "%PLUGIN_BUILD_DIR%" || @exit /b 70
 
-    cmake "%SOURCE_DIR%" -G "Visual Studio 17 2022" -Ax64 %1 %2 %3 %4 %5 %6 %7 %8 %9 --preset default || @exit /b
-    cmake --build . %BUILD_OPTIONS% || @exit /b
+    cmake "%SOURCE_DIR%" -G "Visual Studio 17 2022" -Ax64 %1 %2 %3 %4 %5 %6 %7 %8 %9 --preset default || @exit /b 70
+    cmake --build . %BUILD_OPTIONS% || @exit /b 70
 @echo off
 
 set ARTIFACT=%PLUGIN_BUILD_DIR%\%BUILD_TYPE%\%PLUGIN_NAME%.dll
@@ -65,11 +65,11 @@ set UNIT_TESTS="unit_tests"
 
 set UNIT_TESTS_BUILD_DIR=%BUILD_DIR%\%UNIT_TESTS%
 @echo on
-    if not exist "%UNIT_TESTS_BUILD_DIR%" mkdir "%UNIT_TESTS_BUILD_DIR%" || @exit /b
-    cd "%UNIT_TESTS_BUILD_DIR%" || @exit /b
+    if not exist "%UNIT_TESTS_BUILD_DIR%" mkdir "%UNIT_TESTS_BUILD_DIR%" || @exit /b 70
+    cd "%UNIT_TESTS_BUILD_DIR%" || @exit /b 70
 
-    cmake "%SOURCE_DIR%" -G "Visual Studio 17 2022" -Ax64 %1 %2 %3 %4 %5 %6 %7 %8 %9 --preset default || @exit /b
-    cmake --build . %BUILD_OPTIONS% || @exit /b
+    cmake "%SOURCE_DIR%" -G "Visual Studio 17 2022" -Ax64 %1 %2 %3 %4 %5 %6 %7 %8 %9 --preset default || @exit /b 70
+    cmake --build . %BUILD_OPTIONS% || @exit /b 70
 @echo off
 
 set ARTIFACT=%UNIT_TESTS_BUILD_DIR%\%BUILD_TYPE%\analytics_plugin_ut.exe


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

If the plugin fails on windows, it does not fail with an error code, which prevents our GitHub actions from detecting a failure. This fixes that issue.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #