### PR TITLE
Add size_tracker to components when mounting cloudfuse

### DIFF
--- a/src/lib/cloudfuse/child_process_linux.cpp
+++ b/src/lib/cloudfuse/child_process_linux.cpp
@@ -47,7 +47,7 @@ CloudfuseMngr::CloudfuseMngr()
     // generate template contents
     std::string systemName = getSystemName();
     // NOTE: increment the version number when the config template changes
-    templateVersionString = "template-version: 0.2";
+    templateVersionString = "template-version: 0.3";
     config_template = templateVersionString + R"(
 allow-other: true
 logging:
@@ -56,6 +56,7 @@ logging:
 components:
 - libfuse
 - file_cache
+- size_tracker
 - attr_cache
 - s3storage
 

--- a/src/lib/cloudfuse/child_process_windows.cpp
+++ b/src/lib/cloudfuse/child_process_windows.cpp
@@ -73,7 +73,7 @@ CloudfuseMngr::CloudfuseMngr()
     // generate template contents
     std::string systemName = getSystemName();
     // NOTE: increment the version number when the config template changes
-    templateVersionString = "template-version: 0.2";
+    templateVersionString = "template-version: 0.3";
     config_template = templateVersionString + R"(
 allow-other: true
 logging:
@@ -82,6 +82,7 @@ logging:
 components:
 - libfuse
 - file_cache
+- size_tracker
 - attr_cache
 - s3storage
 


### PR DESCRIPTION
### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

This adds the size_tracker component from cloudfuse into the yaml file and bumps the template version.

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #