### PR TITLE
Check for SaaS Subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ The following will use gcc. You may also replace gcc/g++ with clang/clang++.
 ./build_plugin.sh --no-tests -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
 ```
 
+To be sure of compatibility, use a version 11 compiler:
+
+```bash
+sudo apt install g++-11 -y
+./build_plugin.sh --no-tests -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++-11
+```
+
 After running the script the resulting .so file can be found at
 `../nx-lyve-cloud-plugin-build/cloudfuse_plugin/libcloudfuse_plugin.so`.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following will default to your OS selected C compiler.
 The following will use gcc. You may also replace gcc/g++ with clang/clang++.
 
 ```bash
-./build_plugin.sh --no-tests -DCMAKE_CXX_COMPILER=gcc -DCMAKE_C_COMPILER=g++
+./build_plugin.sh --no-tests -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
 ```
 
 After running the script the resulting .so file can be found at

--- a/install_plugin_linux.sh
+++ b/install_plugin_linux.sh
@@ -31,6 +31,6 @@ apt-get install ./cloudfuse*.deb
 ### Install plugin
 echo "Installing Cloudfuse plugin"
 cp cloudfuse_plugin.so /opt/networkoptix-metavms/mediaserver/bin/plugins/
-systemctl restart networkoptix-mediaserver.service
+systemctl restart networkoptix-metavms-mediaserver.service
 
 echo "Finished installing Cloudfuse plugin"

--- a/src/lib/cloudfuse/child_process.h
+++ b/src/lib/cloudfuse/child_process.h
@@ -33,12 +33,12 @@ struct processReturn
 
 class ChildProcess
 {
-    public:
-    #ifdef _WIN32
-        static processReturn spawnProcess(wchar_t *argv, std::wstring envp);
-    #elif defined(__linux__) || defined(__APPLE__)
-        static processReturn spawnProcess(char *const argv[], char *const envp[]);
-    #endif
+  public:
+#ifdef _WIN32
+    static processReturn spawnProcess(wchar_t *argv, std::wstring envp);
+#elif defined(__linux__) || defined(__APPLE__)
+    static processReturn spawnProcess(char *const argv[], char *const envp[]);
+#endif
 };
 
 class CloudfuseMngr

--- a/src/lib/cloudfuse/child_process.h
+++ b/src/lib/cloudfuse/child_process.h
@@ -31,6 +31,16 @@ struct processReturn
     std::string output; // std err and std out from cloudfuse command
 };
 
+class ChildProcess
+{
+    public:
+    #ifdef _WIN32
+        static processReturn spawnProcess(wchar_t *argv, std::wstring envp);
+    #elif defined(__linux__) || defined(__APPLE__)
+        static processReturn spawnProcess(char *const argv[], char *const envp[]);
+    #endif
+};
+
 class CloudfuseMngr
 {
   public:
@@ -64,9 +74,6 @@ class CloudfuseMngr
     bool templateValid();
     bool writeTemplate();
 #ifdef _WIN32
-    processReturn spawnProcess(wchar_t *argv, std::wstring envp);
     processReturn encryptConfig(const std::string passphrase);
-#elif defined(__linux__) || defined(__APPLE__)
-    processReturn spawnProcess(char *const argv[], char *const envp[]);
 #endif
 };

--- a/src/lib/cloudfuse/child_process_linux.cpp
+++ b/src/lib/cloudfuse/child_process_linux.cpp
@@ -172,7 +172,7 @@ processReturn ChildProcess::spawnProcess(char *const argv[], char *const envp[])
         close(pipefd[1]); // Close write end of pipe
 
         execve(argv[0], argv, envp);
-        
+
         // if execve succeeded, none of the following lines will run
         // print an error message to STDERR, which is piped to the parent
         // this should prevent the parent from hanging (maybe)

--- a/src/lib/cloudfuse/child_process_linux.cpp
+++ b/src/lib/cloudfuse/child_process_linux.cpp
@@ -171,12 +171,15 @@ processReturn CloudfuseMngr::spawnProcess(char *const argv[], char *const envp[]
 
         close(pipefd[1]); // Close write end of pipe
 
-        if (execve(argv[0], argv, envp) == -1)
-        {
-            exit(EXIT_FAILURE);
-        }
-
-        exit(EXIT_SUCCESS);
+        execve(argv[0], argv, envp);
+        
+        // if execve succeeded, none of the following lines will run
+        // print an error message to STDERR, which is piped to the parent
+        // this should prevent the parent from hanging (maybe)
+        char errorMessage[256];
+        std::snprintf(errorMessage, sizeof(errorMessage), "execve(%s, ...) failed", argv[0]);
+        perror(errorMessage);
+        exit(EXIT_FAILURE);
     }
 }
 

--- a/src/lib/cloudfuse/child_process_linux.cpp
+++ b/src/lib/cloudfuse/child_process_linux.cpp
@@ -107,7 +107,7 @@ s3storage:
     }
 }
 
-processReturn CloudfuseMngr::spawnProcess(char *const argv[], char *const envp[])
+processReturn ChildProcess::spawnProcess(char *const argv[], char *const envp[])
 {
     processReturn ret;
 
@@ -208,7 +208,7 @@ processReturn CloudfuseMngr::genS3Config(const std::string endpoint, const std::
                           const_cast<char *>(passphraseKeyEnv.c_str()),
                           NULL};
 
-    return spawnProcess(argv, envp);
+    return ChildProcess::spawnProcess(argv, envp);
 }
 
 processReturn CloudfuseMngr::dryRun(const std::string accessKeyId, const std::string secretAccessKey,
@@ -226,7 +226,7 @@ processReturn CloudfuseMngr::dryRun(const std::string accessKeyId, const std::st
                           const_cast<char *>(awsSecretAccessKeyEnv.c_str()),
                           const_cast<char *>(passphraseKeyEnv.c_str()), NULL};
 
-    return spawnProcess(argv, envp);
+    return ChildProcess::spawnProcess(argv, envp);
 }
 
 processReturn CloudfuseMngr::mount(const std::string accessKeyId, const std::string secretAccessKey,
@@ -243,7 +243,7 @@ processReturn CloudfuseMngr::mount(const std::string accessKeyId, const std::str
                           const_cast<char *>(awsSecretAccessKeyEnv.c_str()),
                           const_cast<char *>(passphraseKeyEnv.c_str()), NULL};
 
-    return spawnProcess(argv, envp);
+    return ChildProcess::spawnProcess(argv, envp);
 }
 
 processReturn CloudfuseMngr::unmount()
@@ -252,7 +252,7 @@ processReturn CloudfuseMngr::unmount()
                           const_cast<char *>(mountDir.c_str()), const_cast<char *>("-z"), NULL};
     char *const envp[] = {const_cast<char *>(PATH.c_str()), NULL};
 
-    return spawnProcess(argv, envp);
+    return ChildProcess::spawnProcess(argv, envp);
 }
 
 bool CloudfuseMngr::isInstalled()
@@ -260,7 +260,7 @@ bool CloudfuseMngr::isInstalled()
     char *const argv[] = {const_cast<char *>("/usr/bin/cloudfuse"), const_cast<char *>("version"), NULL};
     char *const envp[] = {const_cast<char *>(PATH.c_str()), NULL};
 
-    return spawnProcess(argv, envp).errCode == 0;
+    return ChildProcess::spawnProcess(argv, envp).errCode == 0;
 }
 
 bool CloudfuseMngr::isMounted()

--- a/src/lib/cloudfuse/child_process_windows.cpp
+++ b/src/lib/cloudfuse/child_process_windows.cpp
@@ -139,7 +139,7 @@ s3storage:
     }
 }
 
-processReturn CloudfuseMngr::spawnProcess(wchar_t *argv, std::wstring envp)
+processReturn ChildProcess::spawnProcess(wchar_t *argv, std::wstring envp)
 {
     processReturn ret;
 
@@ -282,7 +282,7 @@ processReturn CloudfuseMngr::genS3Config(const std::string accessKeyId, const st
     const std::wstring wargv = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(argv);
     const std::wstring wenvp = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(envp);
 
-    return spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
+    return ChildProcess::spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
 }
 
 processReturn CloudfuseMngr::dryRun(const std::string passphrase)
@@ -294,7 +294,7 @@ processReturn CloudfuseMngr::dryRun(const std::string passphrase)
     const std::wstring wargv = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(argv);
     const std::wstring wenvp = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(envp);
 
-    return spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
+    return ChildProcess::spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
 }
 
 processReturn CloudfuseMngr::mount(const std::string passphrase)
@@ -306,7 +306,7 @@ processReturn CloudfuseMngr::mount(const std::string passphrase)
     const std::wstring wargv = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(argv);
     const std::wstring wenvp = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(envp);
 
-    return spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
+    return ChildProcess::spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
 }
 
 processReturn CloudfuseMngr::unmount()
@@ -317,7 +317,7 @@ processReturn CloudfuseMngr::unmount()
     const std::wstring wargv = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(argv);
     const std::wstring wenvp = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(envp);
 
-    return spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
+    return ChildProcess::spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
 }
 
 bool CloudfuseMngr::isInstalled()
@@ -328,7 +328,7 @@ bool CloudfuseMngr::isInstalled()
     const std::wstring wargv = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(argv);
     const std::wstring wenvp = std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().from_bytes(envp);
 
-    return spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp).errCode == 0;
+    return ChildProcess::spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp).errCode == 0;
 }
 
 bool CloudfuseMngr::isMounted()

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -644,14 +644,14 @@ Json getMediaserverSystemInfo(const std::string port, const std::string apiVersi
     wchar_t systemRoot[MAX_PATH];
     GetEnvironmentVariableW(L"SystemRoot", systemRoot, MAX_PATH);
     const std::wstring curlPath = std::wstring(systemRoot) + LR"(\system32\curl.exe)";
-    const std::wstring wargv = curlPath + L" -sk -m 5 " + wVmsSystemInfoUrl;
+    const std::wstring wargv = curlPath + L" -sk -m 2 " + wVmsSystemInfoUrl;
     const std::wstring wenvp = L"";
     auto processReturn = ChildProcess::spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
 #elif defined(__linux__)
     char *const argv[] = {const_cast<char *>("/usr/bin/curl"),
                           const_cast<char *>("-sk"),
                           const_cast<char *>("-m"),
-                          const_cast<char *>("5"),
+                          const_cast<char *>("2"),
                           const_cast<char *>(vmsSystemInfoUrl.c_str()),
                           NULL};
     char *const envp[] = {NULL};

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -622,8 +622,7 @@ processReturn getServerPort()
     // grep port /opt/networkoptix-metavms/mediaserver/etc/mediaserver.conf
     const std::string vmsConfigPath = "/opt/networkoptix-metavms/mediaserver/etc/mediaserver.conf";
     char *const argv[] = {const_cast<char *>("/usr/bin/sed"), const_cast<char *>("-rn"),
-                          const_cast<char *>("s/port=([0-9]*)/\\1/p"), const_cast<char *>(vmsConfigPath.c_str()),
-                          NULL};
+                          const_cast<char *>("s/port=([0-9]*)/\\1/p"), const_cast<char *>(vmsConfigPath.c_str()), NULL};
     char *const envp[] = {NULL};
     auto processReturn = ChildProcess::spawnProcess(argv, envp);
 #endif
@@ -642,12 +641,16 @@ Json getMediaserverSystemInfo(const std::string port, const std::string apiVersi
     wchar_t systemRoot[MAX_PATH];
     GetEnvironmentVariableW(L"SystemRoot", systemRoot, MAX_PATH);
     const std::wstring curlPath = std::wstring(systemRoot) + LR"(\system32\curl.exe)";
-    const std::wstring wargv = curlPath + L" -k " + wVmsSystemInfoUrl;
+    const std::wstring wargv = curlPath + L" -k -m 5" + wVmsSystemInfoUrl;
     const std::wstring wenvp = L"";
     auto processReturn = ChildProcess::spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
 #elif defined(__linux__)
-    char *const argv[] = {const_cast<char *>("/usr/bin/curl"), const_cast<char *>("-k"),
-                          const_cast<char *>(vmsSystemInfoUrl.c_str()), NULL};
+    char *const argv[] = {const_cast<char *>("/usr/bin/curl"),
+                          const_cast<char *>("-k"),
+                          const_cast<char *>("-m"),
+                          const_cast<char *>("5"),
+                          const_cast<char *>(vmsSystemInfoUrl.c_str()),
+                          NULL};
     char *const envp[] = {NULL};
     auto processReturn = ChildProcess::spawnProcess(argv, envp);
 #endif

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -642,12 +642,12 @@ Json getMediaserverSystemInfo(const std::string port, const std::string apiVersi
     wchar_t systemRoot[MAX_PATH];
     GetEnvironmentVariableW(L"SystemRoot", systemRoot, MAX_PATH);
     const std::wstring curlPath = std::wstring(systemRoot) + LR"(\system32\curl.exe)";
-    const std::wstring wargv = curlPath + L" -k -m 5" + wVmsSystemInfoUrl;
+    const std::wstring wargv = curlPath + L" -sk -m 5" + wVmsSystemInfoUrl;
     const std::wstring wenvp = L"";
     auto processReturn = ChildProcess::spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
 #elif defined(__linux__)
     char *const argv[] = {const_cast<char *>("/usr/bin/curl"),
-                          const_cast<char *>("-k"),
+                          const_cast<char *>("-sk"),
                           const_cast<char *>("-m"),
                           const_cast<char *>("5"),
                           const_cast<char *>(vmsSystemInfoUrl.c_str()),
@@ -667,6 +667,7 @@ Json getMediaserverSystemInfo(const std::string port, const std::string apiVersi
     if (!parseError.empty())
     {
         NX_PRINT << "Failed to parse media server system info JSON. Here's why: " + parseError;
+        NX_PRINT << "Entire JSON input: " << processReturn.output;
         return false;
     }
     // check for API error

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -51,8 +51,6 @@ Engine::Engine(Plugin *plugin)
     : nx::sdk::analytics::Engine(NX_DEBUG_ENABLE_OUTPUT, plugin->instanceId()), m_plugin(plugin), m_cfManager()
 {
     NX_PRINT << "cloudfuse Engine::Engine";
-    // check SaaS subscription
-    m_saasSubscriptionValid = checkSaasSubscription();
 }
 
 Engine::~Engine()
@@ -86,6 +84,9 @@ std::string Engine::manifestString() const
 Result<const ISettingsResponse *> Engine::settingsReceived()
 {
     NX_PRINT << "cloudfuse Engine::settingsReceived";
+    // check SaaS subscription
+    m_saasSubscriptionValid = checkSaasSubscription();
+    NX_PRINT << "SaaS subscription check complete";
     std::string parseError;
     Json::object model = Json::parse(kEngineSettingsModel, parseError).object_items();
     if (parseError != "")

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -113,12 +113,13 @@ Result<const ISettingsResponse *> Engine::settingsReceived()
     // check whether this plugin is authorized by an active SaaS subscription
     SaasSubscriptionResult subscriptionCheckResult = checkSaasSubscription();
     // only update the state if there was no error
+    auto subscriptionStatusJson = kStatusUnkownSaaSSubscription;
     if (subscriptionCheckResult != SaasSubscriptionResult::Error)
     {
         m_saasSubscriptionValid = subscriptionCheckResult == SaasSubscriptionResult::SubscriptionValid ? true : false;
+        subscriptionStatusJson = m_saasSubscriptionValid ? kStatusSaaSSubscriptionVerified : kStatusNoSaaSSubscription;
     }
     // update the UI to show the user a banner
-    auto subscriptionStatusJson = m_saasSubscriptionValid ? kStatusSaaSSubscriptionVerified : kStatusNoSaaSSubscription;
     if (!setStatusBanner(&model, kSubscriptionStatusBannerId, subscriptionStatusJson))
     {
         // on failure, no changes will be written to the model

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -119,6 +119,17 @@ Result<const ISettingsResponse *> Engine::settingsReceived()
     {
         m_saasSubscriptionValid = subscriptionCheckResult == SaasSubscriptionResult::SubscriptionValid ? true : false;
         subscriptionStatusJson = m_saasSubscriptionValid ? kStatusSaaSSubscriptionVerified : kStatusNoSaaSSubscription;
+        // enforce subscription requirement
+        if (!m_saasSubscriptionValid)
+        {
+            NX_PRINT << "Enforcing subscription requirement";
+            mountRequired = false;
+            if (m_cfManager.isMounted())
+            {
+                NX_PRINT << "Unmounting due to invalid subscription";
+                m_cfManager.unmount();
+            }
+        }
     }
     // update the UI to show the user a banner
     if (!setStatusBanner(&model, kSubscriptionStatusBannerId, subscriptionStatusJson))
@@ -128,8 +139,7 @@ Result<const ISettingsResponse *> Engine::settingsReceived()
     }
 
     // if settings have changed, mount the container
-    // TODO: enforce the SaaS subscription
-    bool mountSuccessful;
+    bool mountSuccessful = false;
     if (mountRequired)
     {
         NX_PRINT << "Settings changed.";

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -689,8 +689,12 @@ bool checkSaasSubscription()
                  << portProcessReturn.output;
         return false;
     }
-    // check that the port is numeric
-    const std::string port = portProcessReturn.output;
+    std::string port = portProcessReturn.output;
+    // strip endline(s) and check that the port is numeric
+    while (!port.empty() && (port.back() == '\n' || port.back() == '\r'))
+    {
+        port.erase(port.size() - 1);
+    }
     if (port.empty() || !std::all_of(port.begin(), port.end(), ::isdigit))
     {
         NX_PRINT << "unexpected non-numeric media server port number: " << port;

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -41,7 +41,8 @@ using namespace nx::sdk;
 using namespace nx::sdk::analytics;
 using namespace nx::kit;
 
-enum class SaasSubscriptionResult {
+enum class SaasSubscriptionResult
+{
     SubscriptionValid,
     NoSubscription,
     Error
@@ -125,7 +126,7 @@ Result<const ISettingsResponse *> Engine::settingsReceived()
         // on failure, no changes will be written to the model
         NX_PRINT << "SaaS subscription status message update failed!";
     }
-    
+
     // if settings have changed, mount the container
     // TODO: enforce the SaaS subscription
     bool mountSuccessful;

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -21,6 +21,8 @@
 
 // TODO: get NX_PRINT_PREFIX working with non-member helper functions
 // #define NX_PRINT_PREFIX (this->logUtils.printPrefix)
+#define NX_PRINT_PREFIX "[cloudfuse] "
+// #define NX_DEBUG_ENABLE_OUTPUT true
 #include <nx/kit/debug.h>
 #include <nx/kit/ini_config.h>
 #include <nx/sdk/helpers/active_setting_changed_response.h>
@@ -642,7 +644,7 @@ Json getMediaserverSystemInfo(const std::string port, const std::string apiVersi
     wchar_t systemRoot[MAX_PATH];
     GetEnvironmentVariableW(L"SystemRoot", systemRoot, MAX_PATH);
     const std::wstring curlPath = std::wstring(systemRoot) + LR"(\system32\curl.exe)";
-    const std::wstring wargv = curlPath + L" -sk -m 5" + wVmsSystemInfoUrl;
+    const std::wstring wargv = curlPath + L" -sk -m 5 " + wVmsSystemInfoUrl;
     const std::wstring wenvp = L"";
     auto processReturn = ChildProcess::spawnProcess(const_cast<wchar_t *>(wargv.c_str()), wenvp);
 #elif defined(__linux__)
@@ -658,7 +660,7 @@ Json getMediaserverSystemInfo(const std::string port, const std::string apiVersi
     if (processReturn.errCode != 0)
     {
         NX_PRINT << "cloudfuse Engine::Engine Failed to get media server system information. Here's why: "
-                 << processReturn.output;
+                 << processReturn.output << "(error code " << std::to_string(processReturn.errCode) << ")";
         return Json();
     }
     // try to parse JSON data

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -621,8 +621,9 @@ processReturn getServerPort()
 #elif defined(__linux__)
     // grep port /opt/networkoptix-metavms/mediaserver/etc/mediaserver.conf
     const std::string vmsConfigPath = "/opt/networkoptix-metavms/mediaserver/etc/mediaserver.conf";
-    char *const argv[] = {const_cast<char *>("/usr/bin/grep"), const_cast<char *>(R"('port=\K[0-9]*')"),
-                          const_cast<char *>("-oP"), const_cast<char *>(vmsConfigPath.c_str()), NULL};
+    char *const argv[] = {const_cast<char *>("/usr/bin/sed"), const_cast<char *>("-rn"),
+                          const_cast<char *>("s/port=([0-9]*)/\\1/p"), const_cast<char *>(vmsConfigPath.c_str()),
+                          NULL};
     char *const envp[] = {NULL};
     auto processReturn = ChildProcess::spawnProcess(argv, envp);
 #endif

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -95,7 +95,7 @@ Result<const ISettingsResponse *> Engine::settingsReceived()
     }
 
     // first, let the user know whether this plugin is authorized by an active SaaS subscription
-    auto subscriptionStatusJson = saasSubscriptionValid ? kStatusSaaSSubscriptionVerified : kStatusNoSaaSSubscription;
+    auto subscriptionStatusJson = m_saasSubscriptionValid ? kStatusSaaSSubscriptionVerified : kStatusNoSaaSSubscription;
     if (!setStatusBanner(&model, kSubscriptionStatusBannerId, subscriptionStatusJson))
     {
         // on failure, no changes will be written to the model

--- a/src/plugin/settings/engine.cpp
+++ b/src/plugin/settings/engine.cpp
@@ -117,7 +117,7 @@ Result<const ISettingsResponse *> Engine::settingsReceived()
     auto subscriptionStatusJson = kStatusUnkownSaaSSubscription;
     if (subscriptionCheckResult != SaasSubscriptionResult::Error)
     {
-        m_saasSubscriptionValid = subscriptionCheckResult == SaasSubscriptionResult::SubscriptionValid ? true : false;
+        m_saasSubscriptionValid = subscriptionCheckResult == SaasSubscriptionResult::SubscriptionValid;
         subscriptionStatusJson = m_saasSubscriptionValid ? kStatusSaaSSubscriptionVerified : kStatusNoSaaSSubscription;
         // enforce subscription requirement
         if (!m_saasSubscriptionValid)

--- a/src/plugin/settings/engine.h
+++ b/src/plugin/settings/engine.h
@@ -43,13 +43,15 @@ class Engine : public nx::sdk::analytics::Engine
     bool settingsChanged();
     nx::sdk::Error validateMount();
     nx::sdk::Error spawnMount();
-    bool updateModel(nx::kit::detail::json11::Json::object *model, bool mountSuccessful) const;
+    bool setStatusBanner(nx::kit::detail::json11::Json::object *model, std::string bannerId,
+                         std::string updatedContent) const;
 
   private:
     nx::sdk::analytics::Plugin *const m_plugin;
     CloudfuseMngr m_cfManager;
     std::map<std::string, std::string> m_prevSettings;
     std::string m_passphrase;
+    bool saasSubscriptionValid;
 };
 
 } // namespace settings

--- a/src/plugin/settings/engine.h
+++ b/src/plugin/settings/engine.h
@@ -51,7 +51,7 @@ class Engine : public nx::sdk::analytics::Engine
     CloudfuseMngr m_cfManager;
     std::map<std::string, std::string> m_prevSettings;
     std::string m_passphrase;
-    bool saasSubscriptionValid;
+    bool m_saasSubscriptionValid;
 };
 
 } // namespace settings

--- a/src/plugin/settings/settings_model.h
+++ b/src/plugin/settings/settings_model.h
@@ -155,7 +155,7 @@ static const std::string kStatusUnkownSaaSSubscription = R"json(
         {
             "type": "Banner",
             "name": ")json" + kSubscriptionStatusBannerId +
-                                                     R"json(",
+                                                         R"json(",
             "icon": "info",
             "text": "SaaS subscription status: Pending verification"
         }

--- a/src/plugin/settings/settings_model.h
+++ b/src/plugin/settings/settings_model.h
@@ -151,5 +151,14 @@ static const std::string kStatusNoSaaSSubscription = R"json(
             "text": "Plugin unauthorized - SaaS subscription required"
         }
 )json";
+static const std::string kStatusUnkownSaaSSubscription = R"json(
+        {
+            "type": "Banner",
+            "name": ")json" + kSubscriptionStatusBannerId +
+                                                     R"json(",
+            "icon": "info",
+            "text": "SaaS subscription status: Pending verification"
+        }
+)json";
 
 } // namespace settings

--- a/src/plugin/settings/settings_model.h
+++ b/src/plugin/settings/settings_model.h
@@ -113,11 +113,12 @@ static const std::string kEngineSettingsModel = /*suppress newline*/ 1 + R"json(
 )json";
 
 // status
-static const std::string kStatusBannerId = "connectionStatus";
+static const std::string kBucketStatusBannerId = "connectionStatus";
+static const std::string kSubscriptionStatusBannerId = "subscriptionStatus";
 static const std::string kStatusSuccess = R"json(
         {
             "type": "Banner",
-            "name": ")json" + kStatusBannerId +
+            "name": ")json" + kBucketStatusBannerId +
                                           R"json(",
             "icon": "info",
             "text": "Cloud storage connected successfully!"
@@ -126,17 +127,26 @@ static const std::string kStatusSuccess = R"json(
 static const std::string kStatusFailure = R"json(
         {
             "type": "Banner",
-            "name": ")json" + kStatusBannerId +
+            "name": ")json" + kBucketStatusBannerId +
                                           R"json(",
             "icon": "warning",
             "text": "Cloud storage connection failed!"
         }
 )json";
+static const std::string kStatusSaaSSubscriptionVerified = R"json(
+        {
+            "type": "Banner",
+            "name": ")json" + kSubscriptionStatusBannerId +
+                                                           R"json(",
+            "icon": "info",
+            "text": "Plugin authorized - SaaS subscription verified"
+        }
+)json";
 static const std::string kStatusNoSaaSSubscription = R"json(
         {
             "type": "Banner",
-            "name": ")json" + kStatusBannerId +
-                                          R"json(",
+            "name": ")json" + kSubscriptionStatusBannerId +
+                                                     R"json(",
             "icon": "warning",
             "text": "Plugin unauthorized - SaaS subscription required"
         }

--- a/src/plugin/settings/settings_model.h
+++ b/src/plugin/settings/settings_model.h
@@ -132,5 +132,14 @@ static const std::string kStatusFailure = R"json(
             "text": "Cloud storage connection failed!"
         }
 )json";
+static const std::string kStatusNoSaaSSubscription = R"json(
+        {
+            "type": "Banner",
+            "name": ")json" + kStatusBannerId +
+                                          R"json(",
+            "icon": "warning",
+            "text": "Plugin unauthorized - SaaS subscription required"
+        }
+)json";
 
 } // namespace settings


### PR DESCRIPTION
This feature is not enforced (yet).

There are currently issues with this on server restart. The REST API which is needed to determine the SaaS subscription state is unavailable for some time after the plugin is loaded. This makes the prospect of enforcing this feature on server restart... unpleasant.

### What type of Pull Request is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### Describe your changes in brief

### Checklist

- [x] Tested locally
- [ ] Added new dependencies
- [ ] Updated documentation
- [ ] Added tests

### Related Issues

- Related Issue #
- Closes #